### PR TITLE
showing ERDAP error instead of generic dataset not found error

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -140,7 +140,7 @@ def _cached_dataset_exists(ds_id, request):
     if nc_time < erddap_time - datetime.timedelta(seconds=60):
         print(f"Dataset {ds_id} has been updated on ERDDAP")
         return False
-    
+
     return True
 
 
@@ -251,8 +251,8 @@ def download_glider_dataset(dataset_ids, variables=(), constraints={}, nrt_only=
                 print(f"Downloading {ds_name}")
                 try:
                     ds = e.to_xarray()
-                except:
-                    print(f"No matching data for {ds_name}")
+                except BaseException as ex:
+                    print(ex)
                     continue
                 ds = _clean_dims(ds)
                 print(f"Writing {dataset_nc}")
@@ -266,8 +266,8 @@ def download_glider_dataset(dataset_ids, variables=(), constraints={}, nrt_only=
             e.dataset_id = ds_name
             try:
                 ds = e.to_xarray()
-            except:
-                print(f"No matching data for {ds_name}")
+            except BaseException as ex:
+                print(ex)
                 continue
             ds = _clean_dims(ds)
             if adcp:


### PR DESCRIPTION
Previously, "No matching data for ds_name" was displayed every time something goes wrong with the download. Since there are also timeouts and other errors occurring occasionally, I'd prefer to show the actual ERDAP warning. 
In the particular case of the screenshot, the download times out. I get this increasingly if I don't specify a subset of variables in the utils.download_glider_dataset. No big deal, but nice to know for what reason it goes wrong. 

![Screenshot from 2023-07-19 14-10-07](https://github.com/voto-ocean-knowledge/download_glider_data/assets/37417617/87225b07-cbae-4f8d-bbc8-b11d0db0ccfe)
